### PR TITLE
Updated paseto-dotnet

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -232,30 +232,31 @@
     "audits": []
   },
   {
-    "name": "idaviddesmet/paseto-dotnet",
-    "url": "https://github.com/idaviddesmet/paseto-dotnet",
+    "name": "daviddesmet/paseto-dotnet",
+    "url": "https://github.com/daviddesmet/paseto-dotnet",
     "authors": [
       {
         "name": "David De Smet",
-        "homepage": "https://github.com/idaviddesmet/paseto-dotnet"
+        "homepage": "https://www.desmet.dev"
       }
     ],
-    "comment": null,
+    "comment": "Paseto.NET, a Paseto (Platform-Agnostic Security Tokens) implementation for .NET",
     "language": ".NET",
     "features": {
-      "v1.local": false,
+      "v1.local": true,
       "v1.public": true,
       "v2.local": true,
       "v2.public": true,
-      "v3.local": false,
-      "v3.public": false,
-      "v4.local": false,
-      "v4.public": false
+      "v3.local": true,
+      "v3.public": true,
+      "v4.local": true,
+      "v4.public": true,
+      "paserk": true
     },
     "extra": {
-      "test-vectors-exist": null,
-      "test-vectors-pass": null,
-      "working": null
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
     },
     "audits": []
   },


### PR DESCRIPTION
I've updated my .NET implementation to support v3 & v4 along with PASERK.
The library is also now covered by the test vectors and has been published to NuGet for .NET developers to consume https://www.nuget.org/packages/Paseto.Core/

I also applied Algorithm Lucidity as the implementation guide (there was an issue for that) along with payload validators.